### PR TITLE
Fix default config so it doesn't crash instantly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ formats = flac, v0, 320, v2
 media = sacd, soundboard, web, dvd, cd, dat, vinyl, blu-ray
 24bit_behaviour = 0
 tracker = https://home.opsfet.ch/
-api = https://orpheus.network
+api = https://orpheus.network/
 mode = both
 source = OPS
 ```

--- a/orpheusmorebetter
+++ b/orpheusmorebetter
@@ -193,7 +193,7 @@ def main():
         config.set("orpheus", "24bit_behaviour", "0")
         config.set("orpheus", "tracker", "https://home.opsfet.ch/")
         config.set("orpheus", "mode", "both")
-        config.set("orpheus", "api", "https://orpheus.network")
+        config.set("orpheus", "api", "https://orpheus.network/")
         config.set("orpheus", "source", "OPS")
         config.write(open(args.config, "w"))
         logger.warning("Please edit the configuration file: {0}".format(args.config))


### PR DESCRIPTION
Resolves #8. 
Really, far too annoying relative to how simple the fix is. Come on. It's one character. I feel like it's important enough to make sure the program doesn't crash instantly when installed exactly according to the instructions that you shouldn't wait for the patch you describe in that issue.