### PR TITLE
Add normalization of file names after creating .torrent file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,10 @@ logs/
 .vscode/
 .venv/
 notes.txt
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+Desktop.ini

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Requests==2.32.3
 setuptools==75.3.2
 lxml==5.4.0
 pydantic==2.11.5
+bencodepy==0.9.5


### PR DESCRIPTION
When my files contain non-ASCII characters (like diacritics, accents, symbols etc.), the .torrent file created by `mktorrent` doesn't pass the verification in my Torrent client. This is because of the difference in normalization standard on MacOS (where I create .torrent file) and Linux (where I store files and run Torrent client). For more details see https://github.com/pobrn/mktorrent/issues/14.

I've decided to post-process the .torrent file and add a function to normalize included files. Even though I tested this on my setup with multiple torrents, it would be great if someone else on MacOS could reproduce and confirm having the same issue.

_Side note:_ I also tried to replace `mktorrent` with `torrentool` which is written in Python (https://pypi.org/project/torrentool/). Didn't solve the issue with normalization.