### PR TITLE
Allow a letter prefix in tracknumber tag

### DIFF
--- a/services/tagging.py
+++ b/services/tagging.py
@@ -49,7 +49,8 @@ class TaggingException(Exception):
 
 def valid_fractional_tag(value):
     # m or m/n
-    if re.match(r"""\d+(/(\d+))?$""", value):
+    # Examples: 1, 1/12 A1, A1/12
+    if re.match(r"""^[A-Za-z]?\d+(?:/\d+)?$""", value):
         return True
     else:
         return False

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,27 @@
+import pytest
+
+from services import tagging
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", True),
+        ("A", False),
+        ("01", True),
+        ("A1", True),
+        ("1A", False),
+        ("AA1", False),
+        ("A01", True),
+        ("1/12", True),
+        ("A/12", False),
+        ("01/12", True),
+        ("A1/12", True),
+        ("a1/12", True),
+        ("1A/12", False),
+        ("Z9/10", True),
+        ("B02/03", True),
+        ("AA1/12", False),
+    ],
+)
+def test_valid_fractional_tag(value, expected):
+    assert tagging.valid_fractional_tag(value) is expected


### PR DESCRIPTION
Sometimes tracknumber has a letter prefix. E.g A1, this is usually seen for example in dual sided vinyls, where A1 indicates the first track on side A of the media, and B1 indicates the first track on side B of the media.
Additionally C,D etc can be observed when there are multiple vinyls or CDs in a pack, where C indicates the first side of vinyl 2, and so forth.

This change allows the valid_fractional_tag to be true when there is a letter prefix to the tracknumber.
Accepted examples:
1, 1/12, A1, A1/12

Not accepted examples:
A, A/12, 1A, 1A/12, AA1, AA1/12

regex101 link:
https://regex101.com/r/DxmtOd/2