### PR TITLE
Change cache format

### DIFF
--- a/orpheusmorebetter
+++ b/orpheusmorebetter
@@ -58,6 +58,17 @@ def create_description(
     return description
 
 
+def add_to_cache(seen: dict, id: str, result: str):
+    now = datetime.now()
+    seen.update({
+        id : {
+            "last_check" : now,
+            "result" : result
+            }
+        })
+    return
+
+
 def formats_needed(group: TorrentGroup, torrent: Torrent, supported_formats: list[str]):
     if "" in supported_formats:
         supported_formats.remove("")
@@ -271,7 +282,6 @@ def main():
 
     logger.info("Logging in to Orpheus Network...")
     api = whatapi.WhatAPI(username, password, endpoint, args.totp)
-    seen: set[str]
 
     try:
         with open(args.cache, "rb") as f:
@@ -280,8 +290,16 @@ def main():
         # If the cache file doesn't exist, create a new one
         logger.info("Cache file not found, creating a new one.")
         with open(args.cache, "wb") as f:
-            seen = set()
-            pickle.dump(set(), f)
+            seen = dict()
+            pickle.dump(dict(), f)   
+    if type(seen) is set:
+        logger.info("Cache is old format, creating a new one.")
+        os.remove(args.cache)
+        with open(args.cache, "wb") as f:
+            seen = dict()
+            pickle.dump(dict(), f)
+    assert type(seen) is dict
+    logger.info("Cache size: {0} entries".format(len(seen)))
 
     if args.skip:
         parsed_urls = [
@@ -290,7 +308,7 @@ def main():
         skip = [int(query["torrentid"]) for query in parsed_urls]
         for id in skip:
             logger.info("Skipping torrent {0}".format(str(id)))
-            seen.add(str(id))
+            add_to_cache(seen, str(id),"skipped")
         pickle.dump(seen, open(args.cache, "wb"))
         return
 
@@ -355,7 +373,6 @@ def main():
         release = f"Release found: {group.name} ({group.year})"
         releaseurl = f"  Release URL: {api.release_url(group, torrent)}"
 
-        logger.info("")
         logger.info(release)
         logger.info(releaseurl)
 
@@ -431,6 +448,7 @@ def main():
 
         needed = formats_needed(group, torrent, supported_formats)
         logger.info("  Formats needed: {0}".format(", ".join(f'{e.name} {e.encoding}' for e in needed)))
+        success = True
 
         if needed:
             # Before proceeding, do the basic tag checks on the source
@@ -490,14 +508,20 @@ def main():
                         break
                 except Exception as e:
                     logger.error("      Error adding format {0}: {1}".format(format, e))
+                    success = False
                     traceback.print_exc()
                 finally:
                     shutil.rmtree(tmpdir)
             else:
                 logger.error("    Path not found - skipping: {0}".format(flac_dir))
+                success = False
                 break
-        seen.add(str(torrentid))
+        result = "success" if success else "failure"
+        logger.info("Writing {0} to cache".format(result))
+        add_to_cache(seen, str(torrentid), result)
         pickle.dump(seen, open(args.cache, "wb"))
+        logger.info("")
+
     logger.info("Process complete. Exiting.")
 
 

--- a/services/whatapi.py
+++ b/services/whatapi.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 from models import Torrent, TorrentGroup, Format
 from models.exceptions import RequestException
+from datetime import datetime
 
 # gazelle is picky about case in searches with &media=x
 media_search_map = {
@@ -21,6 +22,8 @@ media_search_map = {
     "web": "WEB",
     "blu-ray": "Blu-ray",
 }
+
+age_to_rescan = 90
 
 lossless_media = set(media_search_map.keys())
 
@@ -142,7 +145,7 @@ class WhatAPI:
         self,
         type: Literal["snatched", "uploaded"],
         media_params: list[str],
-        skip: set[str] | None,
+        skip: dict | None,
     ):
         LOGGER.info(f"Finding {type} torrents")
         url = f"{self.base_url}/torrents.php?type={type}&userid={self.user_id}&format=FLAC"
@@ -181,7 +184,9 @@ class WhatAPI:
                         torrent_id: str = match.group(2)
 
                         if skip is not None and torrent_id in skip:
-                            continue
+                            we_should_skip = self.should_we_skip(skip, torrent_id)
+                            if we_should_skip:
+                                continue
 
                         yield int(group_id), int(torrent_id)
 
@@ -191,7 +196,7 @@ class WhatAPI:
     def get_candidates(
         self,
         mode: str,
-        skip: set[str] | None = None,
+        skip: dict | None = None,
         media: set[str] = lossless_media,
     ):
         if not media.issubset(lossless_media):
@@ -229,7 +234,11 @@ class WhatAPI:
             content = self.get_html(url)
             for group_id, torrent_id in pattern.findall(content):
                 if skip is None or torrent_id not in skip:
-                    yield int(group_id), int(torrent_id)
+                        yield int(group_id), int(torrent_id)
+                else:
+                    we_should_skip = self.should_we_skip(skip, torrent_id)
+                    if we_should_skip == False:
+                        yield int(group_id), int(torrent_id)
 
     def upload(
         self,
@@ -359,3 +368,16 @@ class WhatAPI:
     def get_torrent_info(self, id):
         t_dict = self.request_ajax("torrent", id=id, method="GET")["torrent"]
         return Torrent(**t_dict)
+
+    def should_we_skip(self, skip: dict, torrent_id: str):
+        right_now = datetime.now()
+        last_scan_date = skip[torrent_id]["last_check"]
+        days_diff = right_now - last_scan_date
+        we_should_skip = True
+        if days_diff.days > age_to_rescan:
+            we_should_skip = False
+            LOGGER.info("Found in cache, but rescanning due to age")
+        if skip[torrent_id]["result"] != "success":
+            we_should_skip = False
+            LOGGER.info("Found in cache, but rescanning due to errors/issues")
+        return we_should_skip


### PR DESCRIPTION
Changed cache format from set to dict. This doubles the file size and seek times, but both still very small.

A cache the size of OPS' entire network: 23mb -> 52mb

Doing 20,000 lookups on the above caches: 5300 microseconds -> 13200 microseconds (0.013 seconds)

Also, keeps track of scan age. If release has not been scanned for more than 90 days, scan again.

Also also, keeps track of errors. If release had errors, scan again. Still toying with this one.