### PR TITLE
fix: remove deprecated remaster flag

### DIFF
--- a/models/torrent.py
+++ b/models/torrent.py
@@ -10,7 +10,6 @@ class Torrent(BaseModel):
     format: str
     seeders: int
     snatched: int
-    remastered: bool
     description: str
     remasterYear: int | None = None
     remasterTitle: str

--- a/services/whatapi.py
+++ b/services/whatapi.py
@@ -253,21 +253,13 @@ class WhatAPI:
             "groupid": group.id,
         }
 
-        if torrent.remastered:
-            form.update({
-                "remaster": True,
-                "remaster_year": str(torrent.remasterYear),
-                "remaster_title": torrent.remasterTitle,
-                "remaster_record_label": torrent.remasterRecordLabel,
-                "remaster_catalogue_number": torrent.remasterCatalogueNumber,
-            })
-        else:
-            form.update({
-                "remaster_year": "",
-                "remaster_title": "",
-                "remaster_record_label": "",
-                "remaster_catalogue_number": "",
-            })
+        form.update({
+            "remaster": True,
+            "remaster_year": str(torrent.remasterYear),
+            "remaster_title": torrent.remasterTitle,
+            "remaster_record_label": torrent.remasterRecordLabel,
+            "remaster_catalogue_number": torrent.remasterCatalogueNumber,
+        })
 
         form.update({
             "format": format.name,
@@ -292,12 +284,11 @@ class WhatAPI:
             "bitrate": "24bit Lossless",
             "release_desc": torrent.description,
         }
-        if torrent.remastered:
-            data["remaster"] = "on"
-            data["remaster_year"] = torrent.remasterYear
-            data["remaster_title"] = torrent.remasterTitle
-            data["remaster_record_label"] = torrent.remasterRecordLabel
-            data["remaster_catalogue_number"] = torrent.remasterCatalogueNumber
+        data["remaster"] = "on"
+        data["remaster_year"] = torrent.remasterYear
+        data["remaster_title"] = torrent.remasterTitle
+        data["remaster_record_label"] = torrent.remasterRecordLabel
+        data["remaster_catalogue_number"] = torrent.remasterCatalogueNumber
 
         url = f"{self.base_url}/torrents.php?action=edit&id={torrent.id}"
 


### PR DESCRIPTION
fixes issue #48 

"original release" is now deprecated which means there's no longer a need for the remaster flag.

remove all references to remastered and remove all conditionals related to it.  defaulted all requests to pass through previously defined remastered properties

didn't seem like it made sense to write any tests against this, but i did use this locally for a recent upload and it worked correctly