### PR TITLE
Add option to add torrent to qBittorrent directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ tracker = https://home.opsfet.ch/
 api = https://orpheus.network/
 mode = both
 source = OPS
+
+[qbittorrent]
+enable = false
+host = http://localhost:8080
+username =
+password =
+category =
+tags =
+paused = false
 ```
 
 If you have used `orpheusbetter`, `whatbetter`, or `redbetter`, this is an extremely similar config format.
@@ -93,6 +102,15 @@ If you have used `orpheusbetter`, `whatbetter`, or `redbetter`, this is an extre
  - `none`     - Disable scraping.
 
  `source` is the source flag to add to created torrents. Leave blank if you are running `mktorrent` 1.0.
+
+The optional `[qbittorrent]` section lets `orpheusmorebetter` add finished torrents straight to a running qBittorrent instance via its WebUI API, pointed at the transcode output so qBittorrent rechecks and starts seeding immediately. When this succeeds, the `.torrent` is *not* copied into `torrent_dir`; if it's disabled or the add fails, the tool falls back to the usual `torrent_dir` copy.
+
+ - `enable` - set to `true` to turn on qBittorrent injection.
+ - `host` - base URL of the qBittorrent WebUI, e.g. `http://localhost:8080`.
+ - `username` / `password` - WebUI credentials. Leave both blank if qBittorrent is configured to bypass authentication for localhost clients.
+ - `category` - optional category to assign to added torrents.
+ - `tags` - optional comma-separated tags.
+ - `paused` - set to `true` to add torrents in a paused/stopped state.
 
 You should end up with something like this:
 

--- a/models/exceptions.py
+++ b/models/exceptions.py
@@ -12,3 +12,6 @@ class LoginException(Exception):
 
 class RequestException(Exception):
     pass
+
+class QBittorrentException(Exception):
+    pass

--- a/orpheusmorebetter
+++ b/orpheusmorebetter
@@ -20,7 +20,7 @@ import warnings
 
 from _version import __version__
 
-from services import tagging, transcode, whatapi
+from services import tagging, transcode, whatapi, qbittorrent
 from models import TorrentGroup, Torrent, Format
 import models.format as formats
 
@@ -197,6 +197,18 @@ def main():
         config.set("orpheus", "mode", "both")
         config.set("orpheus", "api", "https://orpheus.network/")
         config.set("orpheus", "source", "OPS")
+        # qBittorrent injection (optional). When enabled, finished torrents are
+        # added straight to qBittorrent pointed at the transcode output instead
+        # of being dropped into torrent_dir. Leave username/password blank if
+        # the WebUI bypasses auth for localhost.
+        config.add_section("qbittorrent")
+        config.set("qbittorrent", "enable", "false")
+        config.set("qbittorrent", "host", "http://localhost:8080")
+        config.set("qbittorrent", "username", "")
+        config.set("qbittorrent", "password", "")
+        config.set("qbittorrent", "category", "")
+        config.set("qbittorrent", "tags", "")
+        config.set("qbittorrent", "paused", "false")
         config.write(open(args.config, "w"))
         logger.warning("Please edit the configuration file: {0}".format(args.config))
         sys.exit(2)
@@ -278,10 +290,32 @@ def main():
         if config.has_option("orpheus", "source"):
             source = config.get("orpheus", "source")
 
+        qbit_enabled = config.getboolean("qbittorrent", "enable", fallback=False)
+        qbit_host = config.get("qbittorrent", "host", fallback="http://localhost:8080")
+        qbit_username = config.get("qbittorrent", "username", fallback="")
+        qbit_password = config.get("qbittorrent", "password", fallback="")
+        qbit_category = config.get("qbittorrent", "category", fallback="")
+        qbit_tags = config.get("qbittorrent", "tags", fallback="")
+        qbit_paused = config.getboolean("qbittorrent", "paused", fallback=False)
+
     upload_torrent = not args.no_upload
 
     logger.info("Logging in to Orpheus Network...")
     api = whatapi.WhatAPI(username, password, endpoint, args.totp)
+
+    qbit_client = None
+    if qbit_enabled:
+        logger.info("Connecting to qBittorrent at {0}...".format(qbit_host))
+        try:
+            qbit_client = qbittorrent.QBittorrentClient(
+                qbit_host, qbit_username, qbit_password
+            )
+        except Exception as e:
+            logger.error(
+                "Could not connect to qBittorrent ({0}); "
+                "falling back to copying torrents into torrent_dir.".format(e)
+            )
+
     seen: set[str]
 
     try:
@@ -495,7 +529,27 @@ def main():
                         logger.info("      Uploading to OPS...")
                         description = create_description(torrent, flac_dir, format)
                         api.upload(group, torrent, new_torrent, format, description)
-                    shutil.copy(new_torrent, local_torrent_dir)
+
+                    added_to_client = False
+                    if qbit_client is not None:
+                        try:
+                            qbit_client.add_torrent(
+                                new_torrent,
+                                savepath=os.path.dirname(transcode_dir),
+                                category=qbit_category or None,
+                                tags=qbit_tags or None,
+                                paused=qbit_paused,
+                            )
+                            logger.info("      Added to qBittorrent.")
+                            added_to_client = True
+                        except Exception as e:
+                            logger.error(
+                                "      Could not add to qBittorrent ({0}); "
+                                "copying to torrent_dir instead.".format(e)
+                            )
+
+                    if not added_to_client:
+                        shutil.copy(new_torrent, local_torrent_dir)
                     logger.info("      Success.")
                     if args.single:
                         break

--- a/services/qbittorrent.py
+++ b/services/qbittorrent.py
@@ -63,7 +63,31 @@ class QBittorrentClient:
 
         savepath should point at the directory that *contains* the torrent's
         top-level folder, so qBittorrent finds the existing files and seeds.
+
+        The persistent session reuses pooled keep-alive connections. If the
+        server closed an idle one in the meantime, the first write fails
+        with a connection reset. Retry once so requests can open a fresh
+        connection.
         """
+        try:
+            return self._add_torrent(
+                torrent_path, savepath, category, tags, paused, auto_tmm
+            )
+        except requests.exceptions.ConnectionError:
+            LOGGER.warning("qBittorrent connection reset; retrying once.")
+            return self._add_torrent(
+                torrent_path, savepath, category, tags, paused, auto_tmm
+            )
+
+    def _add_torrent(
+        self,
+        torrent_path: str,
+        savepath: str | None,
+        category: str | None,
+        tags: str | None,
+        paused: bool,
+        auto_tmm: bool,
+    ):
         with open(torrent_path, "rb") as f:
             files = {
                 "torrents": (

--- a/services/qbittorrent.py
+++ b/services/qbittorrent.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Minimal client for the qBittorrent WebUI API (v2).
+
+Used to inject freshly created torrents straight into a running
+qBittorrent instance, pointed at the transcode output so the client can
+recheck and seed immediately.
+"""
+
+import os
+import logging
+
+import requests
+
+from models.exceptions import QBittorrentException
+
+LOGGER = logging.getLogger("qbittorrent")
+
+
+class QBittorrentClient:
+    def __init__(self, host: str, username: str = "", password: str = ""):
+        # qBittorrent rejects requests whose Referer/Origin don't match the
+        # host (CSRF protection), so normalise the base URL and send it along.
+        self.base_url = host.rstrip("/")
+        self.username = username
+        self.password = password
+
+        self.session = requests.Session()
+        self.session.headers.update({"Referer": self.base_url})
+
+        # When no credentials are configured we assume the WebUI bypasses
+        # authentication (e.g. "Bypass authentication for clients on localhost")
+        # and skip the login round-trip entirely.
+        if username or password:
+            self._login()
+        else:
+            LOGGER.info("No qBittorrent credentials set; assuming auth is bypassed.")
+
+    def _login(self):
+        r = self.session.post(
+            f"{self.base_url}/api/v2/auth/login",
+            data={"username": self.username, "password": self.password},
+        )
+        if r.status_code == 403:
+            raise QBittorrentException(
+                "qBittorrent refused login (403); check that the host is allowed "
+                "to bypass CSRF and that the WebUI is reachable at this address"
+            )
+        r.raise_for_status()
+        if r.text.strip() != "Ok.":
+            raise QBittorrentException("qBittorrent login failed: bad username or password")
+        LOGGER.info("qBittorrent session opened successfully.")
+
+    def add_torrent(
+        self,
+        torrent_path: str,
+        savepath: str | None = None,
+        category: str | None = None,
+        tags: str | None = None,
+        paused: bool = False,
+        auto_tmm: bool = False,
+    ):
+        """Add a .torrent file to qBittorrent.
+
+        savepath should point at the directory that *contains* the torrent's
+        top-level folder, so qBittorrent finds the existing files and seeds.
+        """
+        with open(torrent_path, "rb") as f:
+            files = {
+                "torrents": (
+                    os.path.basename(torrent_path),
+                    f.read(),
+                    "application/x-bittorrent",
+                )
+            }
+
+        data: dict[str, str] = {
+            "autoTMM": "true" if auto_tmm else "false",
+            "paused": "true" if paused else "false",
+            # qBittorrent 5.x renamed paused -> stopped; send both for compat.
+            "stopped": "true" if paused else "false",
+        }
+        if savepath:
+            data["savepath"] = savepath
+        if category:
+            data["category"] = category
+        if tags:
+            data["tags"] = tags
+
+        r = self.session.post(
+            f"{self.base_url}/api/v2/torrents/add", data=data, files=files
+        )
+        r.raise_for_status()
+        if r.text.strip() != "Ok.":
+            raise QBittorrentException(
+                f"qBittorrent rejected the torrent: {r.text.strip() or r.status_code}"
+            )

--- a/services/qbittorrent.py
+++ b/services/qbittorrent.py
@@ -90,7 +90,30 @@ class QBittorrentClient:
             f"{self.base_url}/api/v2/torrents/add", data=data, files=files
         )
         r.raise_for_status()
-        if r.text.strip() != "Ok.":
-            raise QBittorrentException(
-                f"qBittorrent rejected the torrent: {r.text.strip() or r.status_code}"
-            )
+
+        body = r.text.strip()
+
+        # Older qBittorrent returns the plain text "Ok." on success.
+        if body == "Ok.":
+            return
+
+        # Newer qBittorrent returns a JSON summary instead, e.g.
+        # {"added_torrent_ids": [...], "failure_count": 0, "success_count": 1}.
+        # Treat it as success as long as nothing failed and at least one
+        # torrent was added or is pending.
+        try:
+            summary = r.json()
+        except ValueError:
+            summary = None
+
+        if isinstance(summary, dict):
+            if summary.get("failure_count", 0) == 0 and (
+                summary.get("success_count", 0)
+                or summary.get("pending_count", 0)
+                or summary.get("added_torrent_ids")
+            ):
+                return
+
+        raise QBittorrentException(
+            f"qBittorrent rejected the torrent: {body or r.status_code}"
+        )


### PR DESCRIPTION
Prior to this you had to create the torrent files in a watch dir, or import them into your torrent client manually. This change add support to push the torrents directly into qBittorrent, if that fails it falls back to saving the file on disk.