### PR TITLE
Support searching by infohash

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ usage: orpheusmorebetter [-h] [-s] [-j THREADS] [--config CONFIG] [--cache CACHE
                      [release_urls [release_urls ...]]
 
 positional arguments:
-  release_urls          the URL where the release is located (default: None)
+  release_urls          a release URL, or an info hash, identifying the release
+                        (default: None)
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -162,6 +163,20 @@ To transcode and upload a specific release (provided you have already downloaded
 ```bash
 orpheusmorebetter https://orpheus.network/torrents.php?id=1000\&torrentid=1000000
 ```
+
+You don't need the full URL. If you only have the torrent id, a URL with just `torrentid` works too — the group id is looked up automatically:
+
+```bash
+orpheusmorebetter https://orpheus.network/torrents.php?torrentid=1000000
+```
+
+You can also identify a release by its info hash (40 hex characters), which is resolved against the API the same way:
+
+```bash
+orpheusmorebetter DEADBEEF1234567890ABCDEF1234567890ABCDEF
+```
+
+Any of these forms may be mixed together, passed multiple times, or listed one per line in a file given as the single argument.
 
 Note that if you specify a particular release(s), orpheusmorebetter will ignore your configuration's media types and attempt to transcode the releases you have specified regardless of their media type. (so long as they are lossless types)
 

--- a/orpheusmorebetter
+++ b/orpheusmorebetter
@@ -4,6 +4,7 @@ import configparser
 import argparse
 
 import pickle
+import re
 
 from datetime import datetime
 import os
@@ -26,6 +27,36 @@ import models.format as formats
 
 if sys.version_info < (3, 10, 0): # investigate 311
     raise Exception("Requires Python 3.10.0 or newer")
+
+
+# A bittorrent v1 info hash is 40 hex characters.
+HASH_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def arg_to_candidate(api: whatapi.WhatAPI, arg: str) -> tuple[int, int]:
+    """Turn a release URL or an info hash into a (groupid, torrentid) pair.
+
+    If the argument looks like an info hash, the torrent is looked up by hash.
+    Otherwise it's treated as a URL: the `torrentid` is taken from the query
+    string, and the group id is taken from `id` if present, or resolved from
+    the API when only the torrent id is known.
+    """
+    arg = arg.strip()
+
+    if HASH_RE.match(arg):
+        return api.resolve_candidate(hash=arg)
+
+    query = dict(parse_qsl(urlparse(arg).query))
+    if "torrentid" not in query:
+        raise ValueError(
+            "URL is missing a 'torrentid' parameter: {0}".format(arg)
+        )
+
+    torrentid = int(query["torrentid"])
+    if "id" in query:
+        return int(query["id"]), torrentid
+
+    return api.resolve_candidate(torrentid=torrentid)
 
 
 def banner():
@@ -89,7 +120,9 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter, prog="orpheusmorebetter"
     )
     parser.add_argument(
-        "release_urls", nargs="*", help="the URL where the release is located"
+        "release_urls",
+        nargs="*",
+        help="a release URL, or an info hash, identifying the release",
     )
     parser.add_argument(
         "-s",
@@ -295,10 +328,11 @@ def main():
             pickle.dump(set(), f)
 
     if args.skip:
-        parsed_urls = [
-            dict(parse_qsl(urlparse(url).query)) for url in args.release_urls
+        skip = [
+            torrentid for _, torrentid in (
+                arg_to_candidate(api, url) for url in args.release_urls
+            )
         ]
-        skip = [int(query["torrentid"]) for query in parsed_urls]
         for id in skip:
             logger.info("Skipping torrent {0}".format(str(id)))
             seen.add(str(id))
@@ -313,19 +347,15 @@ def main():
                 "You supplied a url list, ignoring your configuration's media types."
             )
             with open(args.release_urls[0]) as f:
-                parsed_urls = [dict(parse_qsl(urlparse(url).query)) for url in f]
                 candidates = [
-                    (int(query["id"]), int(query["torrentid"])) for query in parsed_urls
+                    arg_to_candidate(api, line) for line in f if line.strip()
                 ]
         else:
             logger.info(
                 "You supplied one or more release URLs, ignoring your configuration's media types."
             )
-            parsed_urls = [
-                dict(parse_qsl(urlparse(url).query)) for url in args.release_urls
-            ]
             candidates = [
-                (int(query["id"]), int(query["torrentid"])) for query in parsed_urls
+                arg_to_candidate(api, url) for url in args.release_urls
             ]
     else:
         if args.mode is None:

--- a/services/whatapi.py
+++ b/services/whatapi.py
@@ -303,6 +303,24 @@ class WhatAPI:
     def permalink(self, torrent: Torrent):
         return f"{self.base_url}/torrents.php?torrentid={torrent.id}"
 
+    def resolve_candidate(
+        self, torrentid: int | None = None, hash: str | None = None
+    ) -> tuple[int, int]:
+        """Resolve a (groupid, torrentid) pair from a torrent id or info hash.
+
+        Gazelle's ajax.php?action=torrent accepts either an `id` (torrent id)
+        or a `hash` (uppercase hex info hash) and returns both the group and
+        torrent objects, so we can recover the group id either way.
+        """
+        if torrentid is not None:
+            response = self.request_ajax("torrent", id=torrentid)
+        elif hash is not None:
+            response = self.request_ajax("torrent", hash=hash.upper())
+        else:
+            raise ValueError("resolve_candidate requires a torrentid or a hash")
+
+        return int(response["group"]["id"]), int(response["torrent"]["id"])
+
     def get_better(self, type: int = 3):
         p = re.compile(
             r'(torrents\.php\?action=download&(?:amp;)?id=(\d+)[^"]*).*(torrents\.php\?id=\d+(?:&amp;|&)torrentid=\2\#torrent\d+)',


### PR DESCRIPTION
In some cases we don't have the URL with `torrentid`, but Gazelle's API support searching by info hash as well, so let's support that.